### PR TITLE
Default to overlay for inventory highlight

### DIFF
--- a/src/main/java/begosrs/barbarianassault/BaMinigameConfig.java
+++ b/src/main/java/begosrs/barbarianassault/BaMinigameConfig.java
@@ -253,7 +253,7 @@ public interface BaMinigameConfig extends Config
 	)
 	default InventoryHighlightMode inventoryHighlightMode()
 	{
-		return InventoryHighlightMode.DISABLED;
+		return InventoryHighlightMode.OVERLAY;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
A few plugin users were reporting that the inventory highlight was not working, and this setting is counter intuitive.
In the future it should just be deleted or targeted by the specific config option (aka if healer wants highlighted food, tick "Highlight called poison")