### PR TITLE
Fix parsing npc from penance death messages

### DIFF
--- a/src/main/java/begosrs/barbarianassault/BaMinigamePlugin.java
+++ b/src/main/java/begosrs/barbarianassault/BaMinigamePlugin.java
@@ -713,7 +713,7 @@ public class BaMinigamePlugin extends Plugin
 			{
 				final MessageNode node = chatMessage.getMessageNode();
 				String nodeValue = Text.removeTags(node.getValue());
-				final String npc = message.split(" ")[4];
+				final String npc = nodeValue.split(" ")[4];
 
 				Role role = wave.getRole();
 


### PR DESCRIPTION
the npc names were recolored recently, which broke death times infoboxes

it'd be nice to keep the color on the npc names but cba right now